### PR TITLE
Upgraded dotnet target to 8

### DIFF
--- a/OverdriveDownloader/OverdriveDownloader.csproj
+++ b/OverdriveDownloader/OverdriveDownloader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU</Platforms>

--- a/OverdriveDownloader/Properties/launchSettings.json
+++ b/OverdriveDownloader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OverdriveTEST": {
       "commandName": "Project",
-      "commandLineArgs": "\"C:\\Users\\mbuca\\Downloads\\GoodOmens_9780061967078_276878(1).odm\""
+      "commandLineArgs": "\"C:\\Users\\Chris\\Downloads\\debug\\TheDrawingoftheThree_9781508217442_2517599.odm\""
     }
   }
 }


### PR DESCRIPTION
Upgraded the target dotnet version to 8.0, and test built the application.  Modified the debug settings to pull an ODM file I had on hand, and was able to successfully build the app, download the mp3 parts, and combined them into a single m4b file.